### PR TITLE
CICD

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 sudo: required
 
-language: node_js
-
 services:
   - docker
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ install:
   - docker --version
   - uname -m
   - pip install --user awscli
-  - git clone https://github.com/the-bantam-breaks/website-automation.git
   - docker network create bantam
   - docker run -d --rm -p 28015:28015 -p 8090:8080 --name rethinkdb --network bantam -v $(pwd -P):/data rethinkdb
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,17 +6,33 @@ services:
   - docker
 
 install:
-  - echo "install nothing!"
-
-script:
-  - echo "no tests!"
-
-after_success:
   - docker --version
   - uname -m
   - pip install --user awscli
+  - git clone https://github.com/the-bantam-breaks/website-automation.git
+  - docker network create bantam
+  - docker run -d --rm -p 28015:28015 -p 8090:8080 --name rethinkdb --network bantam -v $(pwd -P):/data rethinkdb
+
+script:
   - export PATH=$PATH:$HOME/.local/bin # put aws in the path
   - eval $(aws ecr get-login --region us-east-1 --no-include-email) #needs AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY envvars
   - docker build -t breaks-website:latest .
+  - docker run -d --rm --network bantam --name website -e RETHINKDB_HOST=rethinkdb -p 3000:3000 breaks-website:latest
+  - sleep 10
+  - |
+    STATUSCODE=$(curl -s -o /dev/null --write-out "%{http_code}" localhost:3000)
+    echo "build $TRAVIS_BUILD_NUMBER returned HTTP $STATUSCODE"
+    if [[ "$STATUSCODE" != 200 ]]; then
+      echo "Test HTTP request to website container failed!"
+      exit 1
+    fi
   - docker tag breaks-website:latest 796520576045.dkr.ecr.us-east-1.amazonaws.com/the-bantam-breaks/breaks-website:latest
+  - docker tag breaks-website:latest 796520576045.dkr.ecr.us-east-1.amazonaws.com/the-bantam-breaks/breaks-website:${TRAVIS_BUILD_NUMBER}
   - docker push 796520576045.dkr.ecr.us-east-1.amazonaws.com/the-bantam-breaks/breaks-website:latest
+  - docker push 796520576045.dkr.ecr.us-east-1.amazonaws.com/the-bantam-breaks/breaks-website:${TRAVIS_BUILD_NUMBER}
+
+after_success:
+  - echo "Build Successful!"
+  - docker logs website
+  - docker kill rethinkdb website
+  - ./cicd/deploy.sh $TRAVIS_BUILD_NUMBER

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,39 +1,13 @@
 FROM node:10
-ENV YARN_VERSION 1.15.2
 
-# yarn
-RUN \
-    curl -fSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz" \
-    && tar -xzf yarn-v$YARN_VERSION.tar.gz -C /opt/ \
-    && ln -snf /opt/yarn-v$YARN_VERSION/bin/yarn /usr/local/bin/yarn \
-    && ln -snf /opt/yarn-v$YARN_VERSION/bin/yarnpkg /usr/local/bin/yarnpkg \
-    && rm yarn-v$YARN_VERSION.tar.gz
-
-# rethinkdb
-RUN apt-get update && \
-    apt-get install -qq -y lsb-release && \
-    echo "deb http://download.rethinkdb.com/apt $(lsb_release --codename --short) main" | \
-    tee /etc/apt/sources.list.d/rethinkdb.list && \
-    wget -qO- https://download.rethinkdb.com/apt/pubkey.gpg | apt-key add - && \
-    apt-get update && \
-    # https://github.com/rethinkdb/rethinkdb/issues/6228#issuecomment-331753821
-    wget -q http://mirrors.kernel.org/ubuntu/pool/main/p/protobuf/libprotobuf9v5_2.6.1-1.3_amd64.deb -O /tmp/libprotobuf9v5_2.6.1-1.3_amd64.deb && \
-    dpkg -i /tmp/libprotobuf9v5_2.6.1-1.3_amd64.deb && \
-    rm /tmp/libprotobuf9v5_2.6.1-1.3_amd64.deb && \
-    apt-get install -qq -y rethinkdb && \
-    apt-get clean && \
-    mkdir /app
-
-# Setup RethinkDB to start
-WORKDIR /app
-COPY package.json .
-COPY yarn.lock .
-RUN yarn
-
-COPY docker/etc /etc
-COPY docker/start.sh .
-#COPY /app/ .
-COPY src ./src
+ADD . /usr/src/app
+WORKDIR /usr/src/app
+COPY docker/start.sh start.sh
+RUN yarn install && \
+    yarn add --dev webpack webpack-cli && \
+    apt-get update -y -qq && \
+    apt-get -y -qq install netcat && \
+    apt-get clean
 
 # Used for healthcheck
 ENV APP_PORT 3000
@@ -45,5 +19,5 @@ ENV NPM_CONFIG_LOGLEVEL info
 # Expose the port on which this app listens
 EXPOSE 3000
 EXPOSE 8080
-ENTRYPOINT ["/init"]
-CMD [ "sh", "-", "./start.sh" ]
+#CMD [ "sh", "-", "./start.sh" ]
+CMD [ "yarn", "start:server" ]

--- a/cicd/deploy.sh
+++ b/cicd/deploy.sh
@@ -5,7 +5,7 @@ REPOSITORY=796520576045.dkr.ecr.us-east-1.amazonaws.com/the-bantam-breaks/breaks
 IMAGE=${REPOSITORY}:${TAG}
 ECS_CLUSTER=bantam-breaks
 ECS_SERVICE=website
-DIR=“$( cd “$( dirname “${BASH_SOURCE[0]}” )” >/dev/null 2>&1 && pwd )”
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 TASK_JSON_TEMPLATE=${DIR}/task.json
 
 TASK_JSON=$(cat $TASK_JSON_TEMPLATE | \

--- a/cicd/deploy.sh
+++ b/cicd/deploy.sh
@@ -5,8 +5,10 @@ REPOSITORY=796520576045.dkr.ecr.us-east-1.amazonaws.com/the-bantam-breaks/breaks
 IMAGE=${REPOSITORY}:${TAG}
 ECS_CLUSTER=bantam-breaks
 ECS_SERVICE=website
+DIR=“$( cd “$( dirname “${BASH_SOURCE[0]}” )” >/dev/null 2>&1 && pwd )”
+TASK_JSON_TEMPLATE=${DIR}/task.json
 
-TASK_JSON=$(cat task.json | \
+TASK_JSON=$(cat $TASK_JSON_TEMPLATE | \
   jq --arg IMAGE "$IMAGE" '.taskDefinition | (.containerDefinitions[] | select(.name == "breaks-website") | .image) |= $IMAGE')
 
 TASK_REVISION_ARN=$(aws ecs register-task-definition \

--- a/cicd/deploy.sh
+++ b/cicd/deploy.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+TAG=$1
+REPOSITORY=796520576045.dkr.ecr.us-east-1.amazonaws.com/the-bantam-breaks/breaks-website
+IMAGE=${REPOSITORY}:${TAG}
+ECS_CLUSTER=bantam-breaks
+ECS_SERVICE=website
+
+TASK_JSON=$(cat task.json | \
+  jq --arg IMAGE "$IMAGE" '.taskDefinition | (.containerDefinitions[] | select(.name == "breaks-website") | .image) |= $IMAGE')
+
+TASK_REVISION_ARN=$(aws ecs register-task-definition \
+  --cli-input-json "$TASK_JSON" | \
+  jq -r '.taskDefinition.taskDefinitionArn')
+
+aws ecs update-service \
+  --cluster $ECS_CLUSTER \
+  --service $ECS_SERVICE \
+  --force-new-deployment \
+  --task-definition $TASK_REVISION_ARN

--- a/cicd/task.json
+++ b/cicd/task.json
@@ -1,0 +1,47 @@
+{
+    "taskDefinition": {
+        "containerDefinitions": [
+            {
+                "name": "breaks-website",
+                "image": "796520576045.dkr.ecr.us-east-1.amazonaws.com/the-bantam-breaks/breaks-website:latest",
+                "cpu": 0,
+                "links": [],
+                "portMappings": [
+                    {
+                        "containerPort": 3000,
+                        "hostPort": 3000,
+                        "protocol": "tcp"
+                    }
+                ],
+                "essential": true,
+                "environment": [
+                    {
+                        "name": "RETHINKDB_HOST",
+                        "value": "rethinkdb.local"
+                    }
+                ],
+                "mountPoints": [],
+                "volumesFrom": [],
+                "logConfiguration": {
+                    "logDriver": "awslogs",
+                    "options": {
+                        "awslogs-group": "/ecs/website",
+                        "awslogs-region": "us-east-1",
+                        "awslogs-stream-prefix": "ecs"
+                    }
+                }
+            }
+        ],
+        "family": "website",
+        "taskRoleArn": "",
+        "executionRoleArn": "arn:aws:iam::796520576045:role/ecsTaskExecutionRole",
+        "networkMode": "awsvpc",
+        "volumes": [],
+        "placementConstraints": [],
+        "requiresCompatibilities": [
+            "FARGATE"
+        ],
+        "cpu": "256",
+        "memory": "512"
+    }
+}

--- a/cicd/task.json
+++ b/cicd/task.json
@@ -3,7 +3,7 @@
         "containerDefinitions": [
             {
                 "name": "breaks-website",
-                "image": "796520576045.dkr.ecr.us-east-1.amazonaws.com/the-bantam-breaks/breaks-website:latest",
+                "image": "",
                 "cpu": 0,
                 "links": [],
                 "portMappings": [

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 
+RETHINKDB_HOST=${RETHINKDB_HOST:-localhost}
+
 # echo "Waiting for RethinkDB to become available"
-while ! nc -z localhost 28015; do sleep 3; done
+while ! nc -z $RETHINKDB_HOST 28015; do sleep 3; done
 
 # Let's sleep 10 seconds to wait for the DB to be ready
 # sleep 10

--- a/src/config.js
+++ b/src/config.js
@@ -3,7 +3,7 @@ const { env } = process;
 export const APP_PORT = env.PORT || 3000;
 
 export const RETHINKDB = {
-    HOST: env.RETHINKDB_HOST || 'rethinkdb',
+    HOST: env.RETHINKDB_HOST || 'rethinkdb.local',
     PORT: env.RETHINKDB_PORT || 28015,
     DATABASE: 'breaksWebsite'
 };

--- a/src/config.js
+++ b/src/config.js
@@ -3,7 +3,7 @@ const { env } = process;
 export const APP_PORT = env.PORT || 3000;
 
 export const RETHINKDB = {
-    HOST: env.RETHINKDB_HOST || 'rethinkdb.local',
+    HOST: env.RETHINKDB_HOST || 'localhost',
     PORT: env.RETHINKDB_PORT || 28015,
     DATABASE: 'breaksWebsite'
 };

--- a/src/config.js
+++ b/src/config.js
@@ -3,7 +3,7 @@ const { env } = process;
 export const APP_PORT = env.PORT || 3000;
 
 export const RETHINKDB = {
-    HOST: 'localhost',
+    HOST: env.RETHINKDB_HOST || 'rethinkdb',
     PORT: env.RETHINKDB_PORT || 28015,
     DATABASE: 'breaksWebsite'
 };

--- a/webpack.config.server.js
+++ b/webpack.config.server.js
@@ -38,7 +38,9 @@ module.exports = {
         new webpack.NoEmitOnErrorsPlugin(),
         new webpack.DefinePlugin({
             "process.env": {
-                "BUILD_TARGET": JSON.stringify('server')
+                "BUILD_TARGET": JSON.stringify('server'),
+                "RETHINKDB_HOST": JSON.stringify(process.env.RETHINKDB_HOST),
+                "RETHINKDB_PORT": JSON.stringify(process.env.RETHINKDB_PORT)
             }
         }),
     ]


### PR DESCRIPTION
basically upon every commit, travis will:

* spin up a rethinkdb container on the travis build worker
* `docker build` the website image
* `docker run` the fresh image
* run curl against the website image end ensure it returns an HTTP 200

If all that works, it will push the website image to AWS Container Registry, and trigger a deployment to deploy the new image to the staging site at http://bantam-breaks-website-alb-693583480.us-east-1.elb.amazonaws.com/